### PR TITLE
Pr/sw language

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ Should be fully compatible with the original version, but minor changes in `meta
 
 ## guide for multi-version and language
 ### Compatibility
-`varVersion` is used to specify the version of the CV, i.e., `modules_cn` and `varLanguage` is used to specify the language of certain entry.
+`varVersion` is used to specify the version of the CV, i.e., `modules_cn` or `modules_SinglePage` in my usage;
+`varLanguage` is used to specify the language of certain entry.
 
 Basic usage is the same as the original version, but you **need** to rename one of the variables in `metadata.typ` as follows:
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,39 @@
   Brilliant CV Submodule
 </h1>
 
-Please refer to the [example repository](https://github.com/mintyfrankie/brilliant-CV) for more information.
+fork from [brilliant-cv-submodule](https://github.com/mintyfrankie/brilliant-CV-submodule)
+
+Add support for multi-version and language
+Should be fully compatible with the original version, but minor changes in `metadata.typ` may be needed.
+
+## guide for multi-version and language
+### Compatibility
+`varVersion` is used to specify the version of the CV, i.e., `modules_cn` and `varLanguage` is used to specify the language of certain entry.
+
+Basic usage is the same as the original version, but you **need** to rename one of the variables in `metadata.typ` as follows:
+
+```tex
+varLanguage -> varVersion
+```
+Then your CV should be fully compatible with the original version.
+
+### In-file language Switch
+
+You can use `languageSwitch` to switch the language of certain entry in the same file.
+
+```tex
+title: languageSwitch((
+      "en":[Master of Science, Electronics],
+      "zh":[理学硕士, 电子学]
+    )),
+```
+Notice the number of `(` and `)`.
+
+it doesn't make sense to use key of `""` in the languageSwitch, But it should be compatible if you do so.
+
+
+Please refer to the [example repository](https://github.com/HernandoR/lz-brilliant-cv) for more information.
+
+
 
 Any issue or PR is welcomed!

--- a/metadata-demo.typ
+++ b/metadata-demo.typ
@@ -53,7 +53,8 @@
 
 #let profilePhoto = "../src/avatar.png" // Leave blank if profil photo is not needed
 
-#let varLanguage = "" // INFO: value must matches folder suffix; i.e "zh" -> "./modules_zh"
+#let varVersion = "" // INFO: value must matches folder suffix; i.e "zh" -> "./modules_zh"
+#let varLanguage = "en" // INFO: value must the key to use ; i.e "zh" -> languageSwitch["zh"]
 
 #let varEntrySocietyFirst = false // Decide if you want to put your company in bold or your position in bold
 

--- a/template.typ
+++ b/template.typ
@@ -27,11 +27,11 @@
 ]
 
 #let autoImport(file) = {
-  if varLanguage == "" {
+  if varVersion == "" {
     include {"../modules/" + file + ".typ"}
   }
   else {
-    include {"../modules_" + varLanguage + "/" + file + ".typ"}
+    include {"../modules_" + varVersion + "/" + file + ".typ"}
   }
 }
 


### PR DESCRIPTION
introduced a `varVersion` to split the duties of the language switch and version switch. 

Detailed usage is in the Readme file.

Basically, `varVersion` is for switch between folder of modules, `varlanguage` is for the different content.

`languageSwtich()` would be used too many times, consider make a shorter name.