### PR TITLE
Allow users to set their own accent color by passing in a color object

### DIFF
--- a/metadata-demo.typ
+++ b/metadata-demo.typ
@@ -49,7 +49,10 @@
 )
 
 /* Layout Setting */
-#let awesomeColor = "skyblue" // Optional: skyblue, red, nephritis, concrete, darknight
+
+// This can be any of the predefined colors: skyblue, red, nephritis, concrete, darknight
+// or alternatively you can define your own using `rgb("#AABBCC")`
+#let awesomeColor = "skyblue"
 
 #let profilePhoto = "../src/avatar.png" // Leave blank if profil photo is not needed
 

--- a/template.typ
+++ b/template.typ
@@ -63,7 +63,13 @@
   darkgray: rgb("#212529"),
 )
 
-#let accentColor = awesomeColors.at(awesomeColor)
+#let accentColor = {
+  if type(awesomeColor) == color {
+    awesomeColor
+  } else {
+    awesomeColors.at(awesomeColor)
+  }
+}
 
 #let beforeSectionSkip = 1pt
 #let beforeEntrySkip = 1pt


### PR DESCRIPTION
This enables users to use their own colors, e.g. from one of the many "resume color" guides on the internet (e.g. https://designshack.net/articles/graphics/resume-color-schemes/).

I decided to check the type of the passed in object instead of e.g. doing some magic string logic ala `awesomeColor.starts-with("#")`, seemed more robust this way.

This also still fails fast since either the user passed in a correct object, or it defaults back to the dictionary lookup that complains about any string that is not a present key -> the user can still be confused why passing in "neongreen" does not work, but no more than before this PR ;)

This does not create any circular dependencies since it requires no knowledge of the rest of the template - just base typst type/function.