### PR TITLE
Make cvSection function optionally highlightable

### DIFF
--- a/template.typ
+++ b/template.typ
@@ -326,16 +326,20 @@
   }
 }
 
-#let cvSection(title) = {
-  let highlightText = title.slice(0,3)
-  let normalText = title.slice(3)
+#let cvSection(title, highlighted: true, letters: 3) = {
+  let highlightText = title.slice(0,letters)
+  let normalText = title.slice(letters)
 
   v(beforeSectionSkip)
   if nonLatinOverwrite {
     sectionTitleStyle(title, color: accentColor)
   } else {
+    if highlighted {
     sectionTitleStyle(highlightText, color: accentColor)
     sectionTitleStyle(normalText, color: black)
+    } else {
+      sectionTitleStyle(title, color: black)
+    }
   }
   h(2pt)
   box(width: 1fr, line(stroke: 0.9pt, length: 100%))


### PR DESCRIPTION
Ciao!  

I really like this work, it's great!  
I'm adding a little functionality to the `cvSection` function here: it's not optional to make highlight the first n (`letters`) characters.

Btw, I was looking for a way to check whether the file `../metadata.typ` exists, and if it doesn't, to simply import `./metadata-demo.typ`, but I think it doesn't exist just yet (https://github.com/typst/typst/issues/2025)