### PR TITLE
feat: make personalInfo customizable

### DIFF
--- a/metadata-demo.typ
+++ b/metadata-demo.typ
@@ -1,4 +1,6 @@
 // NOTICE: Copy this file to your root folder.
+#import "@preview/fontawesome:0.1.0": *
+
 
 /* Personal Information */
 #let firstName = "John"
@@ -10,6 +12,7 @@
   phone: "+33 6 12 34 56 78",
   email: "john.doe@me.org",
   linkedin: "johndoe",
+  //custom-1: (icon: "", text: "example", link: "https://whoami.com"),
   //gitlab: "mintyfrankie",
   //homepage: "jd.me.org",
   //orcid: "0000-0000-0000-0000",
@@ -49,9 +52,7 @@
 )
 
 /* Layout Setting */
-// This can be any of the predefined colors: skyblue, red, nephritis, concrete, darknight
-// or alternatively you can define your own using `rgb("#AABBCC")`
-#let awesomeColor = "skyblue"
+#let awesomeColor = "skyblue" // Optional: skyblue, red, nephritis, concrete, darknight
 
 #let profilePhoto = "../src/avatar.png" // Leave blank if profil photo is not needed
 

--- a/metadata-demo.typ
+++ b/metadata-demo.typ
@@ -1,6 +1,5 @@
 // NOTICE: Copy this file to your root folder.
 
-
 /* Personal Information */
 #let firstName = "John"
 
@@ -11,7 +10,7 @@
   phone: "+33 6 12 34 56 78",
   email: "john.doe@me.org",
   linkedin: "johndoe",
-  //custom-1: (icon: "", text: "example", link: "https://whoami.com"),
+  //custom-1: (icon: "", text: "example", link: "https://example.com"),
   //gitlab: "mintyfrankie",
   //homepage: "jd.me.org",
   //orcid: "0000-0000-0000-0000",

--- a/metadata-demo.typ
+++ b/metadata-demo.typ
@@ -1,5 +1,4 @@
 // NOTICE: Copy this file to your root folder.
-#import "@preview/fontawesome:0.1.0": *
 
 
 /* Personal Information */

--- a/template.typ
+++ b/template.typ
@@ -259,6 +259,17 @@
         linebreak()
         continue
       }
+      if k.contains("custom") {
+        // example value (icon: fa-graduation-cap(), text: "PhD", link: "https://www.example.com")
+        let icon = v.at("icon")
+        let text = v.at("text")
+        let link_value = v.at("link")
+        box({
+          icon + h(5pt)
+          link(link_value)[#text]
+        })
+        continue
+      }
       if v != "" {box({
         
         // Adds icons

--- a/template.typ
+++ b/template.typ
@@ -261,11 +261,12 @@
       }
       if k.contains("custom") {
         // example value (icon: fa-graduation-cap(), text: "PhD", link: "https://www.example.com")
-        let icon = v.at("icon")
-        let text = v.at("text")
-        let link_value = v.at("link")
+        let icon = v.at("icon", default: "")
+        let text = v.at("text", default: "")
+        let link_value = v.at("link", default: "")
         box({
-          icon + h(5pt)
+          icon
+          h(5pt)
           link(link_value)[#text]
         })
         continue


### PR DESCRIPTION
Refering to #18 

Here is a more "flexible" implementation that is not intended to bring breaking change to the template, yet allowing more power-user usage to customize an Info box (for icon, link and text).

A usage of a customizable element in `personalInfo` is to pass a key-value pair whose key contains `custom`, and the value being an array with the following keys:

- `icon`: optional, can pass custom `box` function to manually insert an icon;
- `text`: compulsory;
- `link`: optional, pass a string of hyperlink.

Example:

```
#import "@preview/fontawesome:0.1.0": *

#let personalInfo = (
  ...
  custom-1: (icon: "", text: "example", link: "https://example.com"),
  ...
)
```