### PR TITLE
feat(cvPublication): expose `full` option

### DIFF
--- a/template.typ
+++ b/template.typ
@@ -449,9 +449,10 @@
   bibPath: "",
   keyList: list(),
   refStyle: "apa",
+  refFull: true,
 ) = {
   show bibliography: it => publicationStyle(it)
-  bibliography(bibPath, title: none, style: refStyle, full: true)
+  bibliography(bibPath, title: none, style: refStyle, full: refFull)
 }
 
 #let cvFooter() = {


### PR DESCRIPTION
Often we want just to cite a fraction of the publications listed in the `bibligraphy`.
However, the `full` option was hard-code to `true`. With this you expose the function and you keep the default value as `true`.
The user can toggle  `false` if necessary.