### PR TITLE
feat(pgp): adds a `pgp` entry in metadata

### DIFF
--- a/metadata-demo.typ
+++ b/metadata-demo.typ
@@ -15,6 +15,7 @@
   //homepage: "jd.me.org",
   //orcid: "0000-0000-0000-0000",
   //researchgate: "John-Doe",
+  //pgp: "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
   //extraInfo: "",
 )
 

--- a/template.typ
+++ b/template.typ
@@ -249,6 +249,7 @@
       orcid: fa-orcid(),
       researchgate: fa-researchgate(),
       location: fa-location-dot(),
+      pgp: fa-key(),
       extraInfo: "",
     )
     let n = 1
@@ -290,6 +291,8 @@
           link("https://orcid.org/" + v)[#v]
         } else if k == "researchgate" {
           link("https://www.researchgate.net/profile/" + v)[#v]
+        } else if k == "pgp" {
+          link("https://keys.openpgp.org/search?q=" + v)[#v]
         } else {
           v
         }


### PR DESCRIPTION
Some users might benefit to have a PGP key entry in the CV. This adds a metadata entry that uses the Font Awesome `fa-key` icon. The link related to that is [OpenPGP](https://keys.openpgp.org).

Also updates the metadata-demo with an example like the ORCID.