### PR TITLE
fix(cvHonor): link typo

### DIFF
--- a/template.typ
+++ b/template.typ
@@ -435,7 +435,7 @@
     honorDateStyle(date),
     if issuer == "" {
       honorTitleStyle(title)
-    } else if link != "" { [
+    } else if url != "" { [
       #honorTitleStyle(link(url)[#title]), #honorIssuerStyle(issuer)
     ] } else { [
       #honorTitleStyle(title), #honorIssuerStyle(issuer)


### PR DESCRIPTION
Hi, thanks for providing this template!

Should this be `url` instead of `link` on L438 for the conditional to work? Feel free to ignore if not!

https://github.com/mintyfrankie/brilliant-CV-Submodule/blob/605c4c37e3d725fefe4d8f3c10225741cbd110f6/template.typ#L438-L439