### PR TITLE
fix issue with custom personal info when not at the end

### DIFF
--- a/template.typ
+++ b/template.typ
@@ -269,9 +269,7 @@
           h(5pt)
           link(link_value)[#text]
         })
-        continue
-      }
-      if v != "" {box({
+      } else if v != "" {box({
         
         // Adds icons
         personalInfoIcons.at(k) + h(5pt)


### PR DESCRIPTION
When a custom personal info 
`  custom-docker: (icon: fa-docker(), text: "Docker", link: "https://hub.docker.com/u/user"),`

is not at the end the Hbar is missing to separate it from the next element 

so before it looks like : 
![2024-04-03T23:12:05,530451284-05:00](https://github.com/mintyfrankie/brilliant-CV-Submodule/assets/413330/8053d335-2ed8-483c-8bbc-c96d7f449f56)

and after the change:
![2024-04-03T23:12:25,647933456-05:00](https://github.com/mintyfrankie/brilliant-CV-Submodule/assets/413330/e2595e3b-57f0-4f94-adc8-1d71ebd5f2d4)

this change fix that problem 