### PR TITLE
feat: add box for the profile photo to made it round

### DIFF
--- a/template.typ
+++ b/template.typ
@@ -313,7 +313,7 @@
 
   let makeHeaderPhotoSection() = {
     if profilePhoto != "" {
-      image(profilePhoto, height: 3.6cm)
+      box(image(profilePhoto, height: 3.6cm), radius: 50%, clip: true)
     } else {
       v(3.6cm)
     }


### PR DESCRIPTION
Hello,

Thanks for the template!

I propose to add a box around the profile photo to made it automatically round. Like that, square photos can be used without per-editing.
