### PR TITLE
feat(cvEntry): add url to link to ~company~ society

### DIFF
--- a/template.typ
+++ b/template.typ
@@ -300,6 +300,7 @@
   description: "Description",
   logo: "",
   tags: (),
+  url: "",
 ) = {
   let ifSocietyFirst(condition, field1, field2) = {
     return if condition { field1 } else { field2 }
@@ -314,6 +315,9 @@
   }
   let setLogoContent(path) = {
     return if logo == "" [] else { image(path, width: 100%) }
+  }
+  if url != "" {
+    society = link(url)[#society]
   }
   v(beforeEntrySkip)
   table(


### PR DESCRIPTION
Hi, i added the option to pass an *url* to `cvEntry` that then gets linked on the society text.

Not sure if this is useful, since there's no style hint for recruiters to discover this, but i thought if they wonder about a company they might hover over it and be pleased to see it's clickable?

For you to decide if this is valuable :)